### PR TITLE
add command for removing region warps, fix bugs relating to region portals, fix tppos command

### DIFF
--- a/src/no/runsafe/warpdrive/WarpDrive.java
+++ b/src/no/runsafe/warpdrive/WarpDrive.java
@@ -64,6 +64,7 @@ public class WarpDrive extends RunsafeConfigurablePlugin
 		addComponent(SetPortal.class);
 		addComponent(SetRegionPortal.class);
 		addComponent(SetZoneCommand.class);
+		addComponent(DelRegionPortal.class);
 
 		// Command arguments
 		addComponent(WarpArgument.class);

--- a/src/no/runsafe/warpdrive/commands/DelRegionPortal.java
+++ b/src/no/runsafe/warpdrive/commands/DelRegionPortal.java
@@ -1,0 +1,42 @@
+package no.runsafe.warpdrive.commands;
+
+import no.runsafe.framework.api.IScheduler;
+import no.runsafe.framework.api.IWorld;
+import no.runsafe.framework.api.command.argument.IArgumentList;
+import no.runsafe.framework.api.command.argument.OptionalArgument;
+import no.runsafe.framework.api.command.argument.RequiredArgument;
+import no.runsafe.framework.api.command.argument.WorldArgument;
+import no.runsafe.framework.api.command.player.PlayerAsyncCommand;
+import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.warpdrive.portals.PortalEngine;
+import no.runsafe.warpdrive.portals.PortalWarp;
+
+public class DelRegionPortal extends PlayerAsyncCommand
+{
+	public DelRegionPortal(IScheduler scheduler, PortalEngine engine)
+	{
+		super("delregionportal", "Deletes a region portal.", "runsafe.portal.del",
+			scheduler,
+			new WorldArgument().require(),
+			new RequiredArgument("region")
+		);
+		this.engine = engine;
+	}
+
+	@Override
+	public String OnAsyncExecute(IPlayer player, IArgumentList parameters)
+	{
+		IWorld world = parameters.getRequired("world");
+		String region = parameters.getRequired("region");
+
+		String portal_name = "region_" + world.getName() + '_' + region;
+		PortalWarp warp = engine.getWarp(world, portal_name);
+		if (warp ==  null)
+			return String.format("&cRegion warp %s not found.", portal_name);
+
+		engine.deleteRegionWarp(world, portal_name);
+		return String.format("&aRegion warp %s deleted.", portal_name);
+	}
+
+	private final PortalEngine engine;
+}

--- a/src/no/runsafe/warpdrive/commands/SetRegionPortal.java
+++ b/src/no/runsafe/warpdrive/commands/SetRegionPortal.java
@@ -27,20 +27,19 @@ public class SetRegionPortal extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer player, IArgumentList parameters)
 	{
-		IWorld world = parameters.getValue("world");
-		if (world == null)
-			return null;
-		String region = parameters.getValue("region");
+		IWorld world = parameters.getRequired("world");
+		String region = parameters.getRequired("region");
+
 		String portal_name = "region_" + world.getName() + '_' + region;
 		PortalWarp warp = engine.getWarp(world, portal_name);
 		if (warp != null)
 		{
 			warp.setLocation(player.getLocation());
 			engine.updateWarp(warp);
-			return "&aRegion " + region + " in world " + world.getName() + " warp updated!";
+			return String.format("&aRegion %s in world %s warp updated!", region, world.getName());
 		}
 		engine.createRegionWarp(world, region, portal_name, player.getLocation(), parameters.getValue("permission"));
-		return "&aThe region " + region + " in world " + world.getName() + " has been hooked up to a new portal!";
+		return String.format("&aThe region %s in world %s has been hooked up to a new portal!", region, world.getName());
 	}
 
 	private final PortalEngine engine;

--- a/src/no/runsafe/warpdrive/commands/TeleportPos.java
+++ b/src/no/runsafe/warpdrive/commands/TeleportPos.java
@@ -22,9 +22,11 @@ public class TeleportPos extends PlayerCommand implements IBranchingExecution
 	@Override
 	public String OnExecute(IPlayer player, IArgumentList parameters)
 	{
-		int x = parameters.getRequired("x");
-		int y = parameters.getRequired("y");
-		int z = parameters.getRequired("z");
+		Integer x = parameters.getValue("x");
+		Integer y = parameters.getValue("y");
+		Integer z = parameters.getValue("z");
+		if (x == null || y==null || z == null)
+			return "&cInvalid coordinates. Make sure you're using integers.";
 		if (abs(x) > 30000000 || y > 255 || y < 0 || abs(z) > 30000000)
 			return "&cOutside the world boundaries.";
 		ILocation target = player.getLocation();

--- a/src/no/runsafe/warpdrive/commands/TeleportPos2D.java
+++ b/src/no/runsafe/warpdrive/commands/TeleportPos2D.java
@@ -27,7 +27,7 @@ public class TeleportPos2D extends PlayerCommand implements IBranchingExecution
 		Integer x = parameters.getValue("x");
 		Integer z = parameters.getValue("z");
 		if (x == null || z == null)
-			return "&cInvalid coordinate";
+			return "&cInvalid coordinates. Make sure you're using integers.";
 		if (abs(x) > 30000000 || abs(z) > 30000000)
 			return "&cOutside the world boundaries.";
 		ILocation target = player.getLocation();

--- a/src/no/runsafe/warpdrive/portals/PortalEngine.java
+++ b/src/no/runsafe/warpdrive/portals/PortalEngine.java
@@ -252,8 +252,11 @@ public class PortalEngine implements IPlayerPortal, IConfigurationChanged, IPlay
 	public void createRegionWarp(IWorld portalWorld, String region, String portalName, ILocation destination, String permission)
 	{
 		PortalWarp warp = new PortalWarp(portalName, portalWorld.getLocation(0.0, 0.0, 0.0), destination, PortalType.NORMAL, 0, permission, null, region);
+		String worldName = portalWorld.getName();
+		if (!portals.containsKey(worldName))
+			portals.put(worldName, new HashMap<>());
+		portals.get(worldName).put(warp.getID(), warp);
 		repository.setWarp(warp);
-		portals.get(portalWorld.getName()).put(warp.getID(), warp);
 	}
 
 	public void finalizeWarp(IPlayer player)

--- a/src/no/runsafe/warpdrive/portals/PortalEngine.java
+++ b/src/no/runsafe/warpdrive/portals/PortalEngine.java
@@ -259,6 +259,12 @@ public class PortalEngine implements IPlayerPortal, IConfigurationChanged, IPlay
 		repository.setWarp(warp);
 	}
 
+	public void deleteRegionWarp(IWorld portalWorld, String portalName)
+	{
+		portals.get(portalWorld.getName()).remove(portalName);
+		repository.deleteWarp(portalName);
+	}
+
 	public void finalizeWarp(IPlayer player)
 	{
 		IRegion3D portalArea = scanArea(player.getLocation());

--- a/src/no/runsafe/warpdrive/portals/PortalEngine.java
+++ b/src/no/runsafe/warpdrive/portals/PortalEngine.java
@@ -252,7 +252,7 @@ public class PortalEngine implements IPlayerPortal, IConfigurationChanged, IPlay
 	public void createRegionWarp(IWorld portalWorld, String region, String portalName, ILocation destination, String permission)
 	{
 		PortalWarp warp = new PortalWarp(portalName, portalWorld.getLocation(0.0, 0.0, 0.0), destination, PortalType.NORMAL, 0, permission, null, region);
-		repository.storeWarp(warp);
+		repository.setWarp(warp);
 		portals.get(portalWorld.getName()).put(warp.getID(), warp);
 	}
 
@@ -267,7 +267,7 @@ public class PortalEngine implements IPlayerPortal, IConfigurationChanged, IPlay
 		if (!portals.containsKey(worldName)) // Check if we're missing a container for this world.
 			portals.put(worldName, new HashMap<>()); // Create a new warp container.
 
-		repository.storeWarp(warp); // Store the warp in the database.
+		repository.setWarp(warp); // Store the warp in the database.
 		portals.get(worldName).put(warp.getID(), warp); // Add to the in-memory warp storage.
 	}
 
@@ -335,7 +335,7 @@ public class PortalEngine implements IPlayerPortal, IConfigurationChanged, IPlay
 		if (!portals.containsKey(worldName))
 			portals.put(worldName, new HashMap<>());
 
-		repository.updatePortalWarp(warp); // Store changes in the database.
+		repository.setWarp(warp); // Store changes in the database.
 		portals.get(worldName).put(warp.getID(), warp);
 
 		if (abandoned_portals.containsKey(warp.getID()))

--- a/src/no/runsafe/warpdrive/portals/PortalRepository.java
+++ b/src/no/runsafe/warpdrive/portals/PortalRepository.java
@@ -58,31 +58,18 @@ public class PortalRepository extends Repository
 		database.execute("DELETE FROM warpdrive_portals WHERE ID = ?", warpID);
 	}
 
-	public void storeWarp(PortalWarp warp)
+	public void setWarp(PortalWarp warp)
 	{
 		database.execute(
 			"INSERT INTO warpdrive_portals (ID, world, x, y, z, destWorld, destX, destY, destZ, destYaw, destPitch, radius, permission, portal_field, region) " +
-				"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+				"ON DUPLICATE KEY UPDATE x=VALUES(x), y=VALUES(y), z=VALUES(z), destWorld=VALUES(destWorld), " +
+				"destX=VALUES(destX), destY=VALUES(destY), destZ=VALUES(destZ), destYaw=VALUES(destYaw), destPitch=VALUES(destPitch), " +
+				"radius=VALUES(radius), permission=VALUES(permission), portal_field=VALUES(portal_field), region=VALUES(region)",
 			warp.getID(), warp.getWorldName(), warp.getX(), warp.getY(), warp.getZ(), warp.getDestinationWorldName(),
 			warp.getDestinationX(), warp.getDestinationY(), warp.getDestinationZ(), warp.getDestinationYaw(),
 			warp.getDestinationPitch(), null, warp.getPermission(), warp.getRegion() == null ? null : warp.getRegion().toString(),
 			warp.getEnterRegion()
-		);
-	}
-
-	public void updatePortalWarp(PortalWarp warp)
-	{
-		database.execute(
-			"UPDATE warpdrive_portals " +
-				"SET destWorld = ?, destX = ?, destY = ?, destZ = ?, destYaw = ?, destPitch = ?," +
-				"world = ?, x = ?, y = ?, z = ?, type = ?, portal_field = ?, region = ? " +
-				"WHERE world=? AND ID=?",
-			warp.getDestinationWorldName(), warp.getDestinationX(), warp.getDestinationY(),
-			warp.getDestinationZ(), warp.getDestinationYaw(), warp.getDestinationPitch(),
-			warp.getWorldName(), warp.getX(), warp.getY(), warp.getZ(), warp.getType().ordinal(),
-			warp.getRegion() == null ? null : warp.getRegion().toString(),
-			warp.getEnterRegion(),
-			warp.getWorldName(), warp.getID()
 		);
 	}
 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -42,5 +42,8 @@ commands:
   setregionportal:
     description: Allows setting/editing of region-based portals in-game.
     aliases: [setrp]
+  delregionportal:
+    description: Deletes a region-based portal.
+    aliases: [delrp]
   setzone:
     description: Allows setting your current zone.


### PR DESCRIPTION
fix null pointer exception when using the tppos command with decimal numbers

fix issue where the first region portal set for a world would cause null pointer exceptions and only be registered in the database and not be cached, causing strange behavior.

fix issue where sometimes region portals would be saved locally but not be saved in the database because of a duplicate primary key sql exception